### PR TITLE
Fix #8. Don't break with scenario outlines

### DIFF
--- a/features/scenario_outline.feature
+++ b/features/scenario_outline.feature
@@ -1,0 +1,33 @@
+Feature: Scenario outline
+  Background:
+    Given a file named "examples/support/env.rb" with:
+      """
+      require 'cucumberator'
+      """
+    Given a file named "examples/step_definitions/extra.rb" with:
+      """
+      When(/I do some magical stuff with '(\w+)'/) do |*args|
+        # just example
+      end
+
+      """
+
+  Scenario: without cucumberator step
+    Given a file named "examples/scenario_outline.feature" with:
+      """
+      Feature: example
+        Scenario Outline: run and exit
+          When I do some magical stuff with '<fruit>'
+
+        Examples:
+          | fruit   |
+          | bananas |
+
+      """
+
+    When I run `cucumber examples/scenario_outline.feature` interactively
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      1 step (1 passed)
+      """

--- a/lib/cucumberator/current_step.rb
+++ b/lib/cucumberator/current_step.rb
@@ -4,10 +4,23 @@ module Cucumberator
   class CurrentStep
     attr_accessor :line
 
-    def initialize(scenario)
-      @scenario_sexp = scenario.steps.to_sexp
+    def initialize(environment)
+      @environment = environment
+      check_for_scenario_outline!
+
+      @scenario_sexp = steps.to_sexp
       @offset = 0
       set_line
+    end
+
+    def check_for_scenario_outline!
+      return unless @environment.respond_to?(:scenario_outline)
+
+      @environment = @environment.scenario_outline
+    end
+
+    def steps
+      @environment.instance_variable_get(:@steps)
     end
 
     def increase

--- a/lib/cucumberator/current_step.rb
+++ b/lib/cucumberator/current_step.rb
@@ -6,8 +6,6 @@ module Cucumberator
 
     def initialize(environment)
       @environment = environment
-      check_for_scenario_outline!
-
       @scenario_sexp = steps.to_sexp
       @offset = 0
       set_line
@@ -20,6 +18,7 @@ module Cucumberator
     end
 
     def steps
+      check_for_scenario_outline!
       @environment.instance_variable_get(:@steps)
     end
 


### PR DESCRIPTION
This only patches the error so Cucumber will pass with scenario outlines.

**It does not add support for Scenario Outlines to `cucumberator`.**
I was not able to get it work because theres not `current_visitor` when you run the `Cucumber` example with outline. 
Refs `lib/cucumberator/steps.rb:12`

It seems that `Cucumber` does not pass the `TreeWalker` aka `visitor` down the chain when executing in the outline/example case.
